### PR TITLE
ci: add Terraform CI workflow to main

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,1 +1,59 @@
+name: Terraform CI
+
+on:
+  push:
+    branches:
+      - dev
+      - staging
+      - prod
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - prod
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [ dev, staging, prod ]
+
+    steps:
+      # 1) Grab your code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # 2) Install Terraform
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.5.0'
+
+      # 3) Ensure formatting
+      - name: Terraform fmt (check)
+        working-directory: ${{ matrix.env }}/infra/financial_pipeline
+        run: terraform fmt -check
+
+      # 4) Init without backend so we don’t need AWS creds in CI
+      - name: Terraform init (no-backend)
+        working-directory: ${{ matrix.env }}/infra/financial_pipeline
+        run: terraform init -backend=false
+
+      # 5) Validate your HCL
+      - name: Terraform validate
+        working-directory: ${{ matrix.env }}/infra/financial_pipeline
+        run: terraform validate
+
+      # 6) Produce a plan
+      - name: Terraform plan
+        working-directory: ${{ matrix.env }}/infra/financial_pipeline
+        run: terraform plan -out=tfplan
+
+      # 7) Upload the plan so you can inspect it in the UI
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tfplan-${{ matrix.env }}
+          path: ${{ matrix.env }}/infra/financial_pipeline/tfplan
 # …yaml content…

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -57,3 +57,4 @@ jobs:
           name: tfplan-${{ matrix.env }}
           path: ${{ matrix.env }}/infra/financial_pipeline/tfplan
 # …yaml content…
+


### PR DESCRIPTION
Bring our Terraform CI workflow into the default branch so GitHub Actions will pick it up.